### PR TITLE
Update NtpMonitorDataSource.py with check_ntp instead of check_ntp_peer

### DIFF
--- a/ZenPacks/zenoss/NtpMonitor/datasources/NtpMonitorDataSource.py
+++ b/ZenPacks/zenoss/NtpMonitor/datasources/NtpMonitorDataSource.py
@@ -78,7 +78,7 @@ class NtpMonitorDataSource(ZenPackPersistence, RRDDataSource.RRDDataSource):
         return True
 
     def getCommand(self, context):
-        parts = [binPath('check_ntp_peer')]
+        parts = [binPath('check_ntp')]
         if self.hostname:
             parts.append('-H %s' % self.hostname)
         elif context.manageIp:


### PR DESCRIPTION
check_ntp_peer triggers issues with modern NTP servers. Even changing the noquery option in ntp.conf does not always solve the problem. 